### PR TITLE
Made it possible to customise the split regex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,27 @@ gulp.task('foo', function() {
 
 ### HTML file
 
-The plugin will look for comments of the form:
+By default plugin will look for lines in the HTML like this:
 
-`<!-- split filename.ext -->`
+`<!-- split myFilename.ext -->`
 
-Everything following one of these comments will be piped to a file named `filename.ext`,
+This divider be customised by setting the `splitStr` option to a valid regex value,
+where group 1 represents the desired filename. By default the following regex is used:
+
+```js
+var htmlsplit = require('gulp-htmlsplit');
+
+gulp.task('foo', function() {
+  gulp.src('./*.html')
+    .pipe(htmlsplit(
+      // Where (\S+) represents the group with the file name
+      splitStr: /\s*<!--\s*split\s+(\S+)\s*-->\s*/g
+    ))
+    .pipe(gulp.dest('build'));
+})
+```
+
+Everything following one of these dividers will be piped to a file named `myFilename.ext`,
 until another `split` comment is encountered, or the file ends.
 
 If the HTML file does not begin with a `split` comment, the contents will be discarded

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function split(opts) {
   var self = this;
   var options = opts || {};
   var stop = options.stop || 'stop';
+  var splitStr = options.splitStr || /\s*<!--\s*split\s+(\S+)\s*-->\s*/g;
   return through.obj(function (file, enc, cb) {
     if (file.isNull()) {
       return cb(null, file);
@@ -23,9 +24,8 @@ function split(opts) {
       var contents = file.contents.toString(enc);
 
       // detect split comments and build a list of splits
-      var regex = /\s*<!--\s*split\s+(\S+)\s*-->\s*/g;
       var result, splits = [];
-      while (result = regex.exec(contents)) {
+      while (result = splitStr.exec(contents)) {
         splits.push({ name: result[1], start: result.index + result[0].length });
         if (splits.length > 1) {
           splits[splits.length - 2].end = result.index;


### PR DESCRIPTION
Made a relative small change which makes this plugin much more flexible. It's now possible to pass the `splitStr` option with a regex value to be used for splitting the files.

In our build we use this together with Handlebars templates, for my preference a html comment with the filename is visually too subtile.